### PR TITLE
Refactor markdown escaping helper

### DIFF
--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/nomenarkt/medicine-tracker/backend/internal/domain"
 	"github.com/nomenarkt/medicine-tracker/backend/internal/logic/stockcalc"
+	"github.com/nomenarkt/medicine-tracker/backend/internal/util"
 )
 
 type Client struct {
@@ -38,7 +39,7 @@ func (c *Client) SendTelegramMessage(msg string) error {
 
 	escaped := msg
 	if !strings.Contains(msg, "```") {
-		escaped = escapeMarkdown(msg)
+		escaped = util.EscapeMarkdown(msg)
 	}
 
 	payload := map[string]string{
@@ -64,21 +65,6 @@ func (c *Client) SendTelegramMessage(msg string) error {
 	}
 
 	return nil
-}
-
-func escapeMarkdown(text string) string {
-	replacer := strings.NewReplacer(
-		"_", "\\_",
-		"*", "\\*",
-		"[", "\\[",
-		"]", "\\]",
-		"(", "\\(",
-		")", "\\)",
-		"`", "\\`",
-		".", "\\.",
-		"-", "\\-",
-	)
-	return replacer.Replace(text)
 }
 
 type Update struct {

--- a/backend/internal/usecase/alert.go
+++ b/backend/internal/usecase/alert.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nomenarkt/medicine-tracker/backend/internal/domain/ports"
 	"github.com/nomenarkt/medicine-tracker/backend/internal/logic/forecast"
 	"github.com/nomenarkt/medicine-tracker/backend/internal/logic/stockcalc"
+	"github.com/nomenarkt/medicine-tracker/backend/internal/util"
 )
 
 // StockChecker handles alerting when stock is near depletion.
@@ -54,7 +55,7 @@ func (s *StockChecker) CheckAndAlertLowStock() error {
 
 			alert := fmt.Sprintf(
 				"*%s* will run out in %d day(s)\\!\nRefill before *%s*\nCurrently: *%.2f* pills left\\.",
-				escapeMarkdown(m.Name),
+				util.EscapeMarkdown(m.Name),
 				daysLeft,
 				forecastDate.Format("2006-01-02"),
 				stock,
@@ -98,14 +99,14 @@ func (s *StockChecker) CheckAndAlertLowStock() error {
 			lines = append(lines,
 				fmt.Sprintf("• %d %s on %s",
 					e.Quantity,
-					escapeMarkdown(e.Unit),
+					util.EscapeMarkdown(e.Unit),
 					e.Date.Format("2006-01-02")),
 			)
 		}
 
 		msg := fmt.Sprintf(
 			"*Refill recorded for %s*\\:\n%s",
-			escapeMarkdown(med.Name),
+			util.EscapeMarkdown(med.Name),
 			strings.Join(lines, "\n"),
 		)
 
@@ -117,23 +118,6 @@ func (s *StockChecker) CheckAndAlertLowStock() error {
 		}
 	}
 	return nil
-}
-
-// escapeMarkdown prepares strings for MarkdownV2 safe output
-func escapeMarkdown(text string) string {
-	replacer := strings.NewReplacer(
-		"_", "\\_",
-		"*", "\\*",
-		"[", "\\[",
-		"]", "\\]",
-		"(", "\\(",
-		")", "\\)",
-		"`", "\\`",
-		".", "\\.",
-		"-", "\\-",
-		"!", "\\!",
-	)
-	return replacer.Replace(text)
 }
 
 // OutOfStockService wraps forecast generation logic.

--- a/backend/internal/util/markdown.go
+++ b/backend/internal/util/markdown.go
@@ -1,0 +1,20 @@
+package util
+
+import "strings"
+
+// EscapeMarkdown prepares strings for safe MarkdownV2 output.
+func EscapeMarkdown(text string) string {
+	replacer := strings.NewReplacer(
+		"_", "\\_",
+		"*", "\\*",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"`", "\\`",
+		".", "\\.",
+		"-", "\\-",
+		"!", "\\!",
+	)
+	return replacer.Replace(text)
+}


### PR DESCRIPTION
## Summary
- add new shared util for Telegram markdown escaping
- use util.EscapeMarkdown in telegram client and alert usecase

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6842da0911688329add3546e0d71fad5