### PR TITLE
Make alert ticker interval configurable

### DIFF
--- a/backend/internal/background/ticker.go
+++ b/backend/internal/background/ticker.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func StartStockAlertTicker(handler func() error) {
+func StartStockAlertTicker(handler func() error, interval time.Duration) {
 	go func() {
 		for {
 			log.Println("⏰ Checking stock for Telegram alerts...")
@@ -14,7 +14,7 @@ func StartStockAlertTicker(handler func() error) {
 			} else {
 				log.Println("✅ Stock alert check completed.")
 			}
-			time.Sleep(24 * time.Hour) //test: 1 * time.Minute
+			time.Sleep(interval)
 		}
 	}()
 }


### PR DESCRIPTION
## Summary
- add `interval` parameter to ticker
- parse `ALERT_TICKER_INTERVAL` env var in server
- pass ticker interval to background worker

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684318b3438c8329904ad4f39b8b33e1