### PR TITLE
Improve Telegram API error logging

### DIFF
--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -99,8 +99,12 @@ func (c *Client) PollForCommands(fetchData func() ([]domain.Medicine, []domain.S
 		resp.Body.Close()
 
 		var updates GetUpdatesResponse
-		if err := json.Unmarshal(body, &updates); err != nil || !updates.OK {
+		if err := json.Unmarshal(body, &updates); err != nil {
 			log.Println("Failed to decode Telegram updates:", err)
+			continue
+		}
+		if !updates.OK {
+			log.Printf("Telegram API error status %d: %s", resp.StatusCode, string(body))
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- log Telegram API errors in PollForCommands

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68432950783c8329a44ba1ec3cfaed2f