### PR TITLE
Fix markdown escaping for telegram sendTo

### DIFF
--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -154,10 +154,15 @@ func (c *Client) handleStockCommand(chatID int64, fetchData func() ([]domain.Med
 }
 
 func (c *Client) sendTo(chatID int64, msg string) error {
+	escaped := msg
+	if !strings.Contains(msg, "```") {
+		escaped = util.EscapeMarkdown(msg)
+	}
+
 	payload := url.Values{}
 	payload.Set("chat_id", fmt.Sprintf("%d", chatID))
-	payload.Set("text", msg)
-	payload.Set("parse_mode", "Markdown")
+	payload.Set("text", escaped)
+	payload.Set("parse_mode", "MarkdownV2")
 
 	_, err := http.PostForm(
 		"https://api.telegram.org/bot"+c.Token+"/sendMessage",


### PR DESCRIPTION
## Summary
- update `sendTo` to match escaping logic of `SendTelegramMessage`
- use `MarkdownV2` parse mode

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68433542f3688329aae98a5c9dc3b77b