### PR TITLE
Simplify FlexibleDate method calls

### DIFF
--- a/backend/internal/domain/flexible_date.go
+++ b/backend/internal/domain/flexible_date.go
@@ -37,7 +37,7 @@ func (fd *FlexibleDate) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON ensures we always serialize in "2006-01-02" format
 func (fd FlexibleDate) MarshalJSON() ([]byte, error) {
-	return json.Marshal(fd.Time.Format("2006-01-02"))
+	return json.Marshal(fd.Format("2006-01-02"))
 }
 
 // IsZero allows comparison and validation

--- a/backend/internal/logic/forecast/forecast.go
+++ b/backend/internal/logic/forecast/forecast.go
@@ -35,7 +35,7 @@ func GenerateOutOfStockForecastMessage(
 
 		shouldUpdate := true
 		if m.ForecastOutOfStockDate != nil {
-			saved := m.ForecastOutOfStockDate.Time.UTC().Format("2006-01-02")
+			saved := m.ForecastOutOfStockDate.UTC().Format("2006-01-02")
 			computed := forecastDate.Format("2006-01-02")
 			if saved == computed {
 				shouldUpdate = false

--- a/backend/internal/usecase/alert.go
+++ b/backend/internal/usecase/alert.go
@@ -48,7 +48,7 @@ func (s *StockChecker) CheckAndAlertLowStock() error {
 		log.Printf("🔍 %s: stock=%.2f, forecast=%s, daysLeft=%d", m.Name, stock, forecastDate.Format("2006-01-02"), daysLeft)
 
 		if daysLeft <= 10 {
-			if m.LastAlertedDate != nil && m.LastAlertedDate.Time.Format("2006-01-02") == now.Format("2006-01-02") {
+			if m.LastAlertedDate != nil && m.LastAlertedDate.Format("2006-01-02") == now.Format("2006-01-02") {
 				log.Printf("ℹ️ Already alerted for %s today, skipping.", m.Name)
 				continue
 			}


### PR DESCRIPTION
## Summary
- use embedded FlexibleDate methods directly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68433555eac88329870a2e18a0dec38f