### PR TITLE
Fix response body close error handling

### DIFF
--- a/backend/internal/infra/airtable/client.go
+++ b/backend/internal/infra/airtable/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"time"
@@ -41,7 +42,11 @@ func (c *Client) FetchMedicines() ([]domain.Medicine, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		if cerr := res.Body.Close(); cerr != nil {
+			log.Println("airtable response close error:", cerr)
+		}
+	}()
 
 	body, _ := io.ReadAll(res.Body)
 
@@ -78,7 +83,11 @@ func (c *Client) FetchStockEntries() ([]domain.StockEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		if cerr := res.Body.Close(); cerr != nil {
+			log.Println("airtable response close error:", cerr)
+		}
+	}()
 
 	body, _ := io.ReadAll(res.Body)
 
@@ -127,7 +136,11 @@ func (c *Client) CreateStockEntry(entry domain.StockEntry) error {
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() {
+		if cerr := res.Body.Close(); cerr != nil {
+			log.Println("airtable response close error:", cerr)
+		}
+	}()
 
 	if res.StatusCode >= 300 {
 		b, _ := io.ReadAll(res.Body)
@@ -160,7 +173,11 @@ func (c *Client) UpdateForecastDate(medicineID string, forecastDate, updatedAt t
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() {
+		if cerr := res.Body.Close(); cerr != nil {
+			log.Println("airtable response close error:", cerr)
+		}
+	}()
 
 	if res.StatusCode >= 300 {
 		b, _ := io.ReadAll(res.Body)
@@ -192,7 +209,11 @@ func (c *Client) UpdateLastAlertedDate(medicineID string, date time.Time) error 
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() {
+		if cerr := res.Body.Close(); cerr != nil {
+			log.Println("airtable response close error:", cerr)
+		}
+	}()
 
 	if res.StatusCode >= 300 {
 		b, _ := io.ReadAll(res.Body)

--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -96,7 +96,9 @@ func (c *Client) PollForCommands(fetchData func() ([]domain.Medicine, []domain.S
 			continue
 		}
 		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		if err := resp.Body.Close(); err != nil {
+			log.Println("Telegram response close error:", err)
+		}
 
 		var updates GetUpdatesResponse
 		if err := json.Unmarshal(body, &updates); err != nil {


### PR DESCRIPTION
## Summary
- log Airtable response close errors
- log Telegram response close errors during polling

## Testing
- `make test`
- `make lint` *(fails: errcheck and staticcheck issues)*

------
https://chatgpt.com/codex/tasks/task_e_6843354fcdec83299298d763d731765d