### PR TITLE
Add environment variable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ ENABLE_ALERT_TICKER=false
 ENABLE_TELEGRAM_POLLING=false
 ```
 
+If any required environment variable is missing, the backend exits with a fatal
+error during client initialization, ensuring misconfigurations are caught early.
+
 ---
 
 ## 📦 Alerting & Notifications

--- a/backend/internal/infra/airtable/client.go
+++ b/backend/internal/infra/airtable/client.go
@@ -18,6 +18,15 @@ type Client struct{}
 
 func NewClient() *Client {
 	_ = godotenv.Load()
+
+	// Validate required environment variables to avoid runtime errors
+	if os.Getenv("AIRTABLE_BASE_ID") == "" ||
+		os.Getenv("AIRTABLE_MEDICINES_TABLE") == "" ||
+		os.Getenv("AIRTABLE_ENTRIES_TABLE") == "" ||
+		os.Getenv("AIRTABLE_TOKEN") == "" {
+		log.Fatal("missing Airtable configuration: ensure AIRTABLE_BASE_ID, AIRTABLE_MEDICINES_TABLE, AIRTABLE_ENTRIES_TABLE and AIRTABLE_TOKEN are set")
+	}
+
 	return &Client{}
 }
 

--- a/backend/internal/infra/telegram/client.go
+++ b/backend/internal/infra/telegram/client.go
@@ -28,9 +28,16 @@ type Client struct {
 
 func NewClient() *Client {
 	_ = godotenv.Load()
+
+	token := os.Getenv("TELEGRAM_BOT_TOKEN")
+	chatID := os.Getenv("TELEGRAM_CHAT_ID")
+	if token == "" || chatID == "" {
+		log.Fatal("missing Telegram configuration: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set")
+	}
+
 	return &Client{
-		Token:  os.Getenv("TELEGRAM_BOT_TOKEN"),
-		ChatID: os.Getenv("TELEGRAM_CHAT_ID"),
+		Token:  token,
+		ChatID: chatID,
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure required Airtable variables are set when creating the client
- ensure Telegram token and chat ID are set before use
- mention new validation behaviour in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843cb3872048329b906f338ae923906