### PR TITLE
Update CI to use golangci-lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,11 @@ jobs:
       - name: 🧱 Build binary
         run: go build ./...
 
-      - name: 🧹 Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-          | sh -s -- -b ./bin v1.64.8
-
       - name: 🧹 Run golangci-lint
-        run: ./bin/golangci-lint run
+        uses: golangci/golangci-lint-action@v5
+        with:
+          version: v1.64.8
+          working-directory: backend
 
   docker-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove manual installation of golangci-lint
- run `golangci/golangci-lint-action` in CI workflow

## Testing
- `make -C backend test`

------
https://chatgpt.com/codex/tasks/task_e_68445aff7b4c832990fd43cf96c1649c